### PR TITLE
Fixes sigabort due to stack overflow in hicops when running with many threads

### DIFF
--- a/source/apps/gicops/gicops.cpp
+++ b/source/apps/gicops/gicops.cpp
@@ -326,14 +326,6 @@ status_t main(int_t argc, char_t* argv[])
         status = DSLIM_DeallocateSC();
     }
 
-    /* De-initialize the ion index */
-    if (status == SLM_SUCCESS)
-    {
-        /* De-initialize the ion index */
-        for (uint_t peplen = minlen; peplen <= maxlen; peplen++)
-            status = DSLIM_DeallocateIonIndex(slm_index + peplen - minlen);
-    }
-
 #if defined (USE_TIMEMORY)
     // stop instrumentation
     search_inst.stop();

--- a/source/apps/hicops/hicops.cpp
+++ b/source/apps/hicops/hicops.cpp
@@ -58,7 +58,7 @@ status_t main(int_t argc, char_t* argv[])
     auto env_tool = tim::get_env<std::string>("HICOPS_INST_COMPONENTS", "");
     auto env_enum = tim::enumerate_components(tim::delimit(env_tool));
     env_enum.erase(std::remove_if(env_enum.begin(), env_enum.end(),
-                                  [](int c) { return c == WALL_CLOCK || 
+                                  [](int c) { return c == WALL_CLOCK ||
                                                      c == CPU_UTIL; }),
                                   env_enum.end());
 
@@ -86,8 +86,8 @@ status_t main(int_t argc, char_t* argv[])
     // init MPI
     int provided = -1;
     status = MPI_Init_thread(&argc, &argv, MPI_THREAD_MULTIPLE, &provided);
-    
-    // Check if desired MPI level available 
+
+    // Check if desired MPI level available
     if (provided != MPI_THREAD_MULTIPLE)
     {
         std::cout << "************************ Warning: **************************\n";
@@ -333,7 +333,7 @@ status_t main(int_t argc, char_t* argv[])
     mem_tuple_t  search_mem_inst("search");
 #endif // USE_TIMEMORY
 
-    // Perform the distributed database search 
+    // Perform the distributed database search
     if (status == SLM_SUCCESS)
     {
         MARK_START(dslim_search);
@@ -353,14 +353,6 @@ status_t main(int_t argc, char_t* argv[])
     {
         /* Deallocate the scorecard */
         status = DSLIM_DeallocateSC();
-    }
-
-    /* De-initialize the ion index */
-    if (status == SLM_SUCCESS)
-    {
-        /* De-initialize the ion index */
-        for (uint_t peplen = minlen; peplen <= maxlen; peplen++)
-            status = DSLIM_DeallocateIonIndex(slm_index + peplen - minlen);
     }
 
 #if defined (USE_TIMEMORY)

--- a/source/core/cuda/superstep4/kernel.cu
+++ b/source/core/cuda/superstep4/kernel.cu
@@ -42,7 +42,7 @@ extern gParams params;
 
 // -------------------------------------------------------------------------------------------- //
 
-namespace hcp 
+namespace hcp
 {
 
 namespace gpu
@@ -56,10 +56,10 @@ namespace s4
 
 struct compare_dhCell
 {
-    __host__ __device__ 
+    __host__ __device__
     bool operator()(dhCell lhs, dhCell rhs)
     {
-        return lhs.hyperscore < rhs.hyperscore; 
+        return lhs.hyperscore < rhs.hyperscore;
     }
 };
 
@@ -117,7 +117,7 @@ __host__ void freed_eValues()
     auto driver = hcp::gpu::cuda::driver::get_instance();
 
     auto &&d_evalues = getd_eValues();
-    
+
     if (d_evalues)
     {
         hcp::gpu::cuda::error_check(hcp::gpu::cuda::device_free_async(d_evalues, driver->stream[DATA_STREAM]));

--- a/source/core/dslim_fileout.cpp
+++ b/source/core/dslim_fileout.cpp
@@ -65,10 +65,10 @@ status_t DFile_InitFiles()
                 string_t filename = common + "_" + std::to_string(f) + ".tsv";
                 tsvs[f].open(filename);
 
-                tsvs[f] << "file\t" << "scan_num\t" << "prec_mass\t" << "charge\t" 
-                        << "retention_time\t" << "peptide\t" << "matched_ions\t" 
-                        << "total_ions\t" << "calc_pep_mass\t" << "mass_diff\t" 
-                        << "mod_info\t" << "hyperscore\t" << "expectscore\t" 
+                tsvs[f] << "file\t" << "scan_num\t" << "prec_mass\t" << "charge\t"
+                        << "retention_time\t" << "peptide\t" << "matched_ions\t"
+                        << "total_ions\t" << "calc_pep_mass\t" << "mass_diff\t"
+                        << "mod_info\t" << "hyperscore\t" << "expectscore\t"
                         << "num_hits" << std::endl;
             }
         }
@@ -115,20 +115,14 @@ status_t DFile_PrintScore(Index *index, uint_t specid, float_t pmass, hCell *psm
 
     Index * lclindex = index + psm->idxoffset;
     int_t peplen = lclindex->pepIndex.peplen;
+    if (peplen < params.min_len or peplen > params.max_len)
+    {
+        throw std::runtime_error("Invalid peptide length encountered. Aborting");
+    }
     int_t pepid = psm->psid;
 
-    /* The size is peplen + 1 to add the \0 character at the end */
-    char_t pepseq[peplen + 1];
-
-    /* Write the \0 character to the last position of pepseq buffer */
-    pepseq[peplen] = '\0';
-
-    /* Copy the rest of the string to the pepseq buffer */
-    strncpy((char_t *)&(pepseq[0]), lclindex->pepIndex.seqs +
-             (lclindex->pepEntries[psm->psid].seqID * peplen), peplen);
-
-    /* Make a string from the char [] */
-    string_t pep = pepseq;
+    auto *const pep_string = lclindex->pepIndex.seqs +
+             (lclindex->pepEntries[psm->psid].seqID * peplen);
 
     /* Print the PSM info to the file */
     tsvs[thno]         << queryfiles[psm->fileIndex];
@@ -136,7 +130,7 @@ status_t DFile_PrintScore(Index *index, uint_t specid, float_t pmass, hCell *psm
     tsvs[thno] << '\t' << std::to_string(pmass);
     tsvs[thno] << '\t' << std::to_string(psm->pchg);
     tsvs[thno] << '\t' << std::to_string(psm->rtime);
-    tsvs[thno] << '\t' << pep;
+    tsvs[thno] << '\t' << std::string_view(pep_string, peplen);
     tsvs[thno] << '\t' << std::to_string(psm->sharedions);
     tsvs[thno] << '\t' << std::to_string(psm->totalions);
     tsvs[thno] << '\t' << std::to_string(lclindex->pepEntries[pepid].Mass);

--- a/source/core/dslim_query.cpp
+++ b/source/core/dslim_query.cpp
@@ -310,7 +310,7 @@ status_t DSLIM_SearchManager(Index *index)
     // setup the comm and scheduling handles
     //
     if (status == SLM_SUCCESS)
-        status = DSLIM_Setup_Handles(); 
+        status = DSLIM_Setup_Handles();
 
     //
     // parallel database search
@@ -358,7 +358,7 @@ void GPU_DistributedSearch(Index *index)
             gBatchlock.unlock();
             break;
         }
-        
+
         // increase the gBatchID
         gBatchID++;
 
@@ -387,7 +387,7 @@ void GPU_DistributedSearch(Index *index)
         MARK_END(penal);
 
         auto penalty = ELAPSED_SECONDS(penal);
-        
+
         ptime += penalty;
 
 #ifndef DIAGNOSE
@@ -532,7 +532,7 @@ status_t DistributedSearch(Index *index)
             gBatchlock.unlock();
             break;
         }
-        
+
         // increase the gBatchID
         gBatchID++;
 
@@ -730,27 +730,12 @@ status_t DSLIM_Destroy_Handles(Index *index)
     }
 #endif /* USE_MPI */
 
-    //
-    // Deinitialize
-    //
-
-    /* Delete the scheduler object */
-    if (SchedHandle != nullptr)
-    {
-        /* Deallocate the scheduler module */
-        delete SchedHandle;
-        SchedHandle = nullptr;
-    }
-
     /* Deinitialize the IO module */
     status = DSLIM_Deinit_IO();
 
     if (status == SLM_SUCCESS && params.nodes == 1)
     {
         status = DFile_DeinitFiles();
-
-        delete[] ePtrs;
-        ePtrs = nullptr;
     }
 
     // deinitialize MS2 prep pointers
@@ -994,7 +979,7 @@ status_t DSLIM_QuerySpectrum(Queries<spectype_t> *ss, Index *index, uint_t idxch
                 if (resPtr->cpsms >= 1)
                 {
                     /* Extract the top PSM */
-                    hCell&& psm = resPtr->topK.getMax();
+                    hCell& psm = resPtr->topK.getMax();
 
                     /* Put it in the list */
                     CandidatePSMS[currSpecID + queries] = psm;
@@ -1370,7 +1355,7 @@ VOID DSLIM_IO_Threads_Entry()
 
         /* Extract a chunk and return the chunksize */
         status = Query->extractbatch<int>(QCHUNK, ioPtr, rem_spec);
-        
+
         // update remaining Query entries
         ioPtr->batchNum = Query->Curr_chunk();
         ioPtr->fileNum  = Query->getQfileIndex();

--- a/source/core/include/dslim_comm.h
+++ b/source/core/include/dslim_comm.h
@@ -41,7 +41,7 @@ public:
     friend status_t DSLIM_CarryForward(Index *index, DSLIM_Comm *CommHandle, expeRT *ePtr, hCell *CandidatePSMS, int_t cpsmSize);
     DSLIM_Comm();
     DSLIM_Comm(int_t);
-    virtual ~DSLIM_Comm();
+    ~DSLIM_Comm() = default;
     status_t AddBatch(int_t, int_t, int_t);
 };
 

--- a/source/core/include/dslim_fileout.h
+++ b/source/core/include/dslim_fileout.h
@@ -26,7 +26,7 @@
 
 /* Function Definitions */
 status_t    DFile_PrintPartials(uint_t specid, Results *resPtr);
-status_t    DFile_PrintScore(Index *index, uint_t specid, 
+status_t    DFile_PrintScore(Index *index, uint_t specid,
                              float_t pmass, hCell *psm, double_t e_x, uint_t npsms);
 status_t    DFile_InitFiles();
 status_t    DFile_DeinitFiles();

--- a/source/core/include/expeRT.h
+++ b/source/core/include/expeRT.h
@@ -118,7 +118,7 @@ public:
     expeRT();
 
     /* Destructor */
-    virtual ~expeRT();
+    ~expeRT();
 
     /* Function to reset the data */
     VOID ResetPartialVectors();

--- a/source/core/include/lwbuff.h
+++ b/source/core/include/lwbuff.h
@@ -72,7 +72,7 @@ public:
         sem_init(&lockw, 0, 1);
     }
 
-    virtual ~lwbuff()
+    ~lwbuff()
     {
         cap = 0;
         thr_low = 0;

--- a/source/core/include/lwqueue.h
+++ b/source/core/include/lwqueue.h
@@ -17,7 +17,7 @@
  *
  */
 
-#pragma once 
+#pragma once
 
 #include "common.hpp"
 #include <semaphore.h>
@@ -56,6 +56,10 @@ public:
     lwqueue(int_t dcap)
     {
         cap = dcap;
+        if (cap <= 0)
+        {
+            throw std::runtime_error("lwqueue initialized with zero capacity. Aborting");
+        }
         arr = new T[cap];
         filled = 0;
         head = 0;
@@ -86,6 +90,10 @@ public:
     lwqueue(int_t dcap, BOOL sem)
     {
         cap = dcap;
+        if (cap <= 0)
+        {
+            throw std::runtime_error("lwqueue initialized with zero capacity. Aborting");
+        }
         arr = new T[cap];
         filled = 0;
         head = 0;
@@ -120,7 +128,7 @@ public:
         }
     }
 
-    virtual ~lwqueue()
+    ~lwqueue()
     {
         delete[] arr;
         arr = NULL;

--- a/source/core/include/lwvector.h
+++ b/source/core/include/lwvector.h
@@ -57,6 +57,8 @@ public:
     lwvector(int_t dsiz)
     {
         cap = dsiz;
+        if (cap <= 0)
+            throw std::runtime_error("lwvector created with zero capacity. Aborting");
         arr = new T [cap];
         head = 0;
         tail = 0;
@@ -78,6 +80,8 @@ public:
     lwvector(T *p1, T *p2)
     {
         cap = 2 * std::distance(p1, p2);
+        if (cap <= 0)
+            throw std::runtime_error("lwvector created with zero capacity. Aborting");
         arr = new T[cap];
         head = 0;
         tail = 0;
@@ -93,6 +97,9 @@ public:
 
     lwvector(int_t dsiz, T val)
     {
+        if (dsiz <= 0)
+            throw std::runtime_error("lwvector created with zero size. Aborting");
+
         arr = new T [dsiz];
         cap = dsiz;
         head = 0;
@@ -144,7 +151,7 @@ public:
         }
     }
 
-    virtual ~lwvector()
+    ~lwvector()
     {
         head = tail = 0;
         sze = cap = 0;

--- a/source/core/include/minheap.h
+++ b/source/core/include/minheap.h
@@ -36,7 +36,7 @@ private:
     int capacity;
     T* array;
 
-    int heapify(int element_position); 
+    int heapify(int element_position);
     void swap(T&, T&);
     void swap(int, int);
 
@@ -46,37 +46,31 @@ public:
     {
         this->capacity = 0;
         this->size = 0;
-        this->array = NULL;
+        this->array = nullptr;
     }
 
     minHeap(int capacity)
     {
         this->capacity = capacity;
         this->size = 0;
+        if (!this->capacity)
+        {
+            throw std::runtime_error("minHeap initialized with zero capacity. Aborting");
+        }
         this->array = new T[this->capacity];
     }
 
-    ~minHeap()
-    {
-        this->capacity = 0;
-        this->size = 0;
-
-        if (this->array != NULL)
-        {
-            delete[] this->array;
-            this->array = NULL;
-        }
-    }
+    ~minHeap() = default;
 
     int init(int capacity);
     int reset();
-    int insert(T &element); 
+    int insert(T &element);
     int get_capacity();
     int get_size();
-    T extract_min(); 
+    T extract_min();
     int decrease_key(int element_position, T new_value);
     int increase_key(int element_position, T new_value);
-    int heap_sort(T *output_array); 
+    int heap_sort(T *output_array);
     T show_element(int element_position);
     T getMax();
 };
@@ -177,7 +171,7 @@ int minHeap<T>::heapify(int element_position)
 }
 
 template<class T>
-T minHeap<T>::extract_min() 
+T minHeap<T>::extract_min()
 {
     if (size < 1)
     {
@@ -186,7 +180,7 @@ T minHeap<T>::extract_min()
 
     T min = array[0];
     swap(array[0], array[size - 1]);
-    size--; 
+    size--;
     heapify(0);
     return min;
 }

--- a/source/core/include/scheduler.h
+++ b/source/core/include/scheduler.h
@@ -69,7 +69,7 @@ private:
 public:
     Scheduler();
     Scheduler(int_t);
-    virtual ~Scheduler();
+    ~Scheduler();
 
     status_t dispatchThread();
     int_t    getNumActivThds();


### PR DESCRIPTION
This PR fixes the sigabort due to stack overflow when many threads are concurrently creating strings and writing them to output files. Instead of creating strings, we just create non-owning `std::string_view`s from the sequence data we already have.

Fixes https://github.com/pcdslab/GiCOPS/issues/17